### PR TITLE
Support pagination of get_users

### DIFF
--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -84,7 +84,18 @@ class Slack(Chat):
                     }
             }
         '''
-        return self._api_call('users.list')['members']
+        members = []
+        next_cursor = None
+        while True:
+            response = self._api_call('users.list', cursor=next_cursor)
+            active_members = [m for m in response['members'] if m.get('deleted') is False]
+            members.extend(active_members)
+            logging.debug('Fetched {} members', len(members))
+            next_cursor = response['response_metadata'].get('next_cursor')
+            if not next_cursor:
+                break
+
+        return members
 
     def get_messages(self):
         # type () -> List[Dict[str, Any]]

--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -90,9 +90,10 @@ class Slack(Chat):
             response = self._api_call('users.list', cursor=next_cursor)
             active_members = [m for m in response['members'] if m.get('deleted') is False]
             members.extend(active_members)
-            logging.debug('Fetched {} members', len(members))
-            next_cursor = response['response_metadata'].get('next_cursor')
-            if not next_cursor:
+            logging.debug('Fetched {} members'.format(len(members)))
+
+            metadata = response.get('response_metadata')
+            if not metadata or not metadata.get('next_cursor'):
                 break
 
         return members


### PR DESCRIPTION
This PR will support pagination in `get_users`.  

Currently, the default `get_users` will return 1000 users, which doesn't work for orgs/companies that have > 1000 users.

Worth also noting that this API endpoint has a ratelimit (https://api.slack.com/methods/users.list) that will easily hit with large Slack workspaces, however this PR doesn't address that.