### PR TITLE
Re-try API requests if Slack API rate limit has been reached.

### DIFF
--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -90,9 +90,10 @@ class Slack(Chat):
             response = self._api_call('users.list', cursor=next_cursor)
             active_members = [m for m in response['members'] if m.get('deleted') is False]
             members.extend(active_members)
-            logging.debug('Fetched {} members', len(members))
-            next_cursor = response['response_metadata'].get('next_cursor')
-            if not next_cursor:
+            logging.debug('Fetched {} members'.format(len(members)))
+
+            metadata = response.get('response_metadata')
+            if not metadata or metadata.get('next_cursor'):
                 break
 
         return members

--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -61,7 +61,7 @@ class Slack(Chat):
             if cur_try > RATE_LIMIT_TRIES:
                 raise ChatException('Slack rate limit max tries reached.')
 
-            if response.get('error', '').lower() == 'ratelimited' and rate_limit_retry is True:
+            if response.get('error', '').lower() == 'ratelimited' and rate_limit_retry:
                 logging.debug('Rate limiting reached.  Sleeping {}.'.format(RATE_LIMIT_SLEEP))
                 cur_try += 1
                 time.sleep(RATE_LIMIT_SLEEP)
@@ -105,7 +105,7 @@ class Slack(Chat):
         next_cursor = None
         while True:
             response = self._api_call('users.list', cursor=next_cursor)
-            active_members = [m for m in response['members'] if m.get('deleted') is False]
+            active_members = [m for m in response['members'] if not m.get('deleted')]
             members.extend(active_members)
             logging.debug('Fetched {} members'.format(len(members)))
 

--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -84,7 +84,18 @@ class Slack(Chat):
                     }
             }
         '''
-        return self._api_call('users.list')['members']
+        members = []
+        next_cursor = None
+        while True:
+            response = self._api_call('users.list', cursor=next_cursor)
+            active_members = [m for m in response['members'] if m.get('deleted') is False]
+            members.extend(active_members)
+            logging.debug('Fetched {} members', len(members))
+            next_cursor = response['response_metadata'].get('next_cursor')
+            if not next_cursor:
+                break
+
+        return members
 
     def get_messages(self):
         # type () -> List[Dict[str, Any]]

--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -90,9 +90,10 @@ class Slack(Chat):
             response = self._api_call('users.list', cursor=next_cursor)
             active_members = [m for m in response['members'] if m.get('deleted') is False]
             members.extend(active_members)
-            logging.debug('Fetched {} members', len(members))
-            next_cursor = response['response_metadata'].get('next_cursor')
-            if not next_cursor:
+            logging.debug('Fetched {} members'.format(len(members)))
+
+            metadata = response.get('response_metadata')
+            if not metadata or not metadata.get('next_cursor'):
                 break
 
         return members


### PR DESCRIPTION
It's easy to hit ratelimits with large orgs, especially when paginating users.  This addition will retry requests every 10s for 1 minute.