### PR TITLE
Support pagination of get_users and add retries if rate limited

### DIFF
--- a/securitybot/chat/slack.py
+++ b/securitybot/chat/slack.py
@@ -7,6 +7,7 @@ __email__ = 'abertsch@dropbox.com'
 import logging
 from slackclient import SlackClient
 import json
+import time
 
 from securitybot.user import User
 from securitybot.chat.chat import Chat, ChatException
@@ -84,7 +85,22 @@ class Slack(Chat):
                     }
             }
         '''
-        return self._api_call('users.list')['members']
+        members = []
+        next_cursor = None
+        while True:
+            response = self._api_call('users.list', cursor=next_cursor)
+            if response.get('error', '').lower() == 'ratelimited':
+                logging.debug('Hit rate limiting on users.list.  Sleeping 10s and trying again.')
+                time.sleep(10)
+            else:
+                active_members = [m for m in response['members'] if m.get('deleted') is False]
+                members.extend(active_members)
+                logging.debug('Fetched {} members', len(members))
+                next_cursor = response['response_metadata'].get('next_cursor')
+                if not next_cursor:
+                    break
+
+        return members
 
     def get_messages(self):
         # type () -> List[Dict[str, Any]]


### PR DESCRIPTION
Re-opening this PR now that it's working as intended in our environment.  Also made some of the initial pep8 formatting.  :-]

This PR will:
- Paginate fetching of users in `get_users`
- Retry requests every 10s for 1 minute in case rate limits are hit, which will happen when paginating users.  